### PR TITLE
Issue: Fix response time color ranging

### DIFF
--- a/js/leafletMap.js
+++ b/js/leafletMap.js
@@ -97,8 +97,8 @@ class LeafletMap {
 
     //Color Scales
 
-    vis.responseScale = d3.scaleSequential()
-      .interpolator(d3.interpolateOrRd);
+    vis.responseScale = d3.scaleLinear()
+      .range(["blue", "red"]);
     vis.neighborhoodScale = d3.scaleOrdinal(d3.schemeCategory10);//Neighborhood
     vis.priorityScale = d3.scaleOrdinal()//Priority
       .domain(["LOW","MEDIUM","HIGH"])

--- a/js/main.js
+++ b/js/main.js
@@ -309,6 +309,19 @@ d3.csv("data/Cincinnati311.csv")
         row.SR_TYPE = normalizeTypeCode(d.SR_TYPE);
         row.SR_TYPE_DESC = cleanText(d.SR_TYPE_DESC, row.SR_TYPE);
 
+        // Calculate response_days from DATE_CREATED and DATE_CLOSED
+        if (d.DATE_CREATED && d.DATE_CLOSED) {
+          const created = new Date(d.DATE_CREATED);
+          const closed = new Date(d.DATE_CLOSED);
+          if (!isNaN(created) && !isNaN(closed)) {
+            row.response_days = (closed - created) / (1000 * 60 * 60 * 24);
+          } else {
+            row.response_days = null;
+          }
+        } else {
+          row.response_days = null;
+        }
+
         return row;
       })
       .filter((d) => Number.isFinite(d.LATITUDE) && Number.isFinite(d.LONGITUDE));


### PR DESCRIPTION
- Add range of blue-red depending on the time length of the request.
- Red is the longest and light-blue-ish is the shortest. Dark blue usually refers to middle range